### PR TITLE
Fix #290 - Social media titles

### DIFF
--- a/ministries/fusion/index.html
+++ b/ministries/fusion/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/styles/style.css?version=20040301">
     <link rel="stylesheet" href="../styles/ministries_style.css">
-    <link rel="stylesheet" href="./styles/fusion_styles.css?version=20040301">
+    <link rel="stylesheet" href="./styles/fusion_styles.css?version=20040303">
 
     <!-- Fav Icons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/fav_icons/apple-touch-icon.png">
@@ -116,7 +116,6 @@
 
                     <div class="content-wrapper">
                         <div class="placeholder-bottom">
-                            <h2>Youtube</h2>
                             <p>Check out our Youtube page for all our content!</p><br>
                             <div class="center"><a class="button--white"
                                     href="https://www.youtube.com/channel/UCtG-IjzwIMsunV4e-dD3xvQ" target="_blank">Go
@@ -135,7 +134,6 @@
 
                     <div class="content-wrapper">
                         <div class="placeholder-bottom">
-                            <h2>Instagram</h2>
                             <p>Check out our Instagram for updates and interactions!</p><br>
                             <div class="center"><a class="button--white"
                                     href="http://instagram.com/cornerstonefusionyouth" target="_blank">Go to
@@ -153,7 +151,6 @@
 
                     <div class="content-wrapper">
                         <div class="placeholder-bottom">
-                            <h2>TikTok</h2>
                             <p>Check out Fusion's TikTok to stay connected while home!</p><br>
                             <center><a class="button--white" href="https://vm.tiktok.com/G1tpPj/" target="_blank">Go
                                     to TikTok</a></center>
@@ -170,7 +167,6 @@
 
                     <div class="content-wrapper">
                         <div class="placeholder-bottom">
-                            <h2>Parents Facebook Group</h2>
                             <p>Follow our Facebook Group to keep up with everything Fusion Youth is doing throughout the
                                 year.</p><br>
                             <center><a class="button--white" href="https://www.facebook.com/groups/996341427386062/"
@@ -189,7 +185,6 @@
 
                     <div class="content-wrapper">
                         <div class="placeholder-bottom">
-                            <h2>Sermon Notes</h2>
                             <p>Miss a service? Want to dive in deeper to what you heard? Check out Pastor Mike's sermon
                                 notes!</p><br>
                             <center><a class="button--white"

--- a/ministries/fusion/styles/fusion_animation.css
+++ b/ministries/fusion/styles/fusion_animation.css
@@ -1,0 +1,19 @@
+/*
+    A stylesheet that quickly moves the social media
+    menu buttons out of the way, then back so they
+    are not accidentally tapped on from a collapsed
+    menu.
+
+    See fusion_style.css to see the implementation.
+*/
+@keyframes disableButton {
+    0% {
+        transform: translate(-150vw, -50%);
+    }
+    1% {
+        transform: translate(-50%, -50%);
+    }
+    100% {
+        transform: translate(-50%, -50%);
+    }
+}

--- a/ministries/fusion/styles/fusion_styles.css
+++ b/ministries/fusion/styles/fusion_styles.css
@@ -1,3 +1,5 @@
+@import "fusion_animation.css";
+
 h1 {
     padding: 20px 0;
 }
@@ -16,7 +18,6 @@ h2 {
     height: 50px;
     width: 100%;
     overflow: hidden;
-
     position: relative;
 }
 
@@ -36,7 +37,7 @@ h2 {
     position: absolute;
     top:  25px;
     left: 20px;
-    z-index: 2;
+    z-index: 3;
 
     font-size: 30px;
     transform: translatey(-50%);
@@ -50,7 +51,7 @@ h2 {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-
+    /* visibility: hidden; */
     color: var(--theme-primary-color);
 }
 
@@ -70,7 +71,7 @@ h2 {
     width: 100%;
     height: 100%;
 
-    background: rgba(0, 0, 0, 0);
+    background: rgba(0, 0, 0, 0.7);
     z-index: 2;
     opacity: 0;
 
@@ -79,14 +80,16 @@ h2 {
 
 .class-selector:hover {
     height: 300px;
+    visibility: visible;
 }
 
 .class-selector:hover .content-wrapper {
     opacity: 1;
 }
 
-.class-selector:hover .placeholder-top h2 {
-    opacity: 1;
+.class-selector:hover .placeholder-bottom {
+    animation: disableButton;
+    animation-duration: 0.5s;
 }
 
 .class-selector p {

--- a/ministries/fusion/styles/fusion_styles.css
+++ b/ministries/fusion/styles/fusion_styles.css
@@ -51,7 +51,6 @@ h2 {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    /* visibility: hidden; */
     color: var(--theme-primary-color);
 }
 
@@ -80,7 +79,6 @@ h2 {
 
 .class-selector:hover {
     height: 300px;
-    visibility: visible;
 }
 
 .class-selector:hover .content-wrapper {

--- a/ministries/fusion/styles/fusion_styles.css
+++ b/ministries/fusion/styles/fusion_styles.css
@@ -34,7 +34,7 @@ h2 {
 
 .class-selector .placeholder-top h2 {
     position: absolute;
-    top:  50%;
+    top:  25px;
     left: 20px;
     z-index: 2;
 
@@ -70,7 +70,7 @@ h2 {
     width: 100%;
     height: 100%;
 
-    background: rgba(0, 0, 0, .8);
+    background: rgba(0, 0, 0, 0);
     z-index: 2;
     opacity: 0;
 
@@ -86,7 +86,7 @@ h2 {
 }
 
 .class-selector:hover .placeholder-top h2 {
-    opacity: 0;
+    opacity: 1;
 }
 
 .class-selector p {


### PR DESCRIPTION
Fix #290 
- Social media titles stay visible
- Moved social media titles in front of opacity layer
- Added animation to move button out of the way from press when collapsed
- Removed titles from placeholder-bottom