### PR TITLE
Add header fixes

### DIFF
--- a/scripts/interactive_style.js
+++ b/scripts/interactive_style.js
@@ -23,11 +23,9 @@ function headerTrans() {
     setTimeout(() => {
         // Make sure function does not run if there is an alert
         if (hasAlert == null || !hasAlert) {
-            var header = document.querySelector("header");
-            header.classList.add('header-transparent');
-            enableLightText();
+            isScrolling = true;
 
-            headerTransparent = true;
+            headerScroll();
         }
     }, 1000);
 }

--- a/scripts/sitewide-search.js
+++ b/scripts/sitewide-search.js
@@ -1,7 +1,9 @@
 var initialDownload = false;
 
-function downloadSearchResults() {
+function openSearchBar() {
     var searchBar = document.getElementById('globalSearchBar');
+
+    searchBar.classList.add('open');
 
     if (!initialDownload) {
         var db = firebase.firestore();
@@ -16,6 +18,41 @@ function downloadSearchResults() {
         if (searchBar.value != "") {
             showSearchResults();
         }
+    }
+}
+
+function closeSearchBar() {
+    var searchBar = document.getElementById('globalSearchBar');
+
+    if (searchBar.value == "") {
+        searchBar.classList.remove('open');
+
+        hideSearchResults();
+    }
+}
+
+function searchBarKeyDetect(e) {
+    switch (e.key) {
+        case 'Enter':
+            e.preventDefault();
+
+            var items = document.querySelectorAll('#siteSearchResult li');
+
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].style.display != "none") {
+                    items[i].querySelector('a').click();
+                    break;
+                }
+            }
+            break;
+        case 'Escape':
+            e.preventDefault();
+
+            e.target.value = "";
+            closeSearchBar();
+            break;
+        default:
+            break;
     }
 }
 
@@ -84,11 +121,8 @@ function createSearchItem(link, title, keywords, description) {
 
 function hideSearchResults() {
     var results = document.querySelector('#siteSearchResult');
-    // Added a timeout because when clicking a link the results would disappear before the mouse down registered.
-    // This allows the input to be recognized before closing.
-    setTimeout(function () {
-        results.style.display = "none";
-    }, 100);
+
+    results.style.display = "none";
 }
 
 function showSearchResults() {

--- a/styles/header.css
+++ b/styles/header.css
@@ -266,7 +266,7 @@ header #searchBar input {
         width 0.25s cubic-bezier(0.4, 0.0, 0.2, 1);
 }
 
-header #searchBar input:focus {
+header #searchBar input.open {
     border-left-width: 2px;
     border-right-width: 2px;
     opacity: 1;
@@ -274,7 +274,7 @@ header #searchBar input:focus {
     width: 175px;
 }
 
-header #searchBar input:focus+#search-button {
+header #searchBar input.open+#search-button {
     cursor: default;
     margin: 0;
     margin-top: 13.5px;
@@ -368,7 +368,7 @@ header #siteSearchResult #no-results--error {
         margin-top: 18px;
     }
 
-    header #searchBar input:focus+#search-button {
+    header #searchBar input.open+#search-button {
         margin-top: 28px;
     }
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -35,9 +35,9 @@
             </ul>
         </nav>
         <label id="searchBar">
-            <input id="globalSearchBar" type="text" placeholder="Search" onkeyup="querySearchResults()"
-                onfocus="downloadSearchResults()" onfocusout="hideSearchResults()" />
-            <img id="search-button" src="/ref/icons/search-dark.png" alt="Search CAG.org" onclick="showSearchBar()" />
+            <input id="globalSearchBar" type="search" placeholder="Search" oninput="querySearchResults()"
+                onfocus="openSearchBar()" onfocusout="closeSearchBar()" onkeydown="searchBarKeyDetect(event)"/>
+            <img id="search-button" src="/ref/icons/search-dark.png" alt="Search CAG.org" />
         </label>
         <nav id="mobile-nav--button">
             <a id="hamburger-button" onclick="toggleMobileNav()">


### PR DESCRIPTION
Changes include:
- Close search bar only when input is blank (initially the search results hid if keyboard users tried tabbing to them)
- Fix non-keyboard input changes not detecting
- If enter is pressed while focused on the search bar, navigates to the first link
- If escape if pressed while focused on the search bar, removes text in input and hides search results
- Fix header theme changing in the middle of home page