### PR TITLE
Fix incorrect Pastors & Staff title

### DIFF
--- a/about/pastors/index.html
+++ b/about/pastors/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
 
 <head>
-    <title>Missions Projects | Cornerstone Church</title>
+    <title>Pastors & Staff | Cornerstone Church</title>
     <meta charset="utf8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/styles/style.css?version=21011401">


### PR DESCRIPTION
Pastors & Staff page was mistakenly titled Missions Projects.